### PR TITLE
change submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "addons/GifMaker/godot-gdgifexporter"]
 	path = addons/GifMaker/godot-gdgifexporter
-	url = git@github.com:jegor377/godot-gdgifexporter.git
+	url = https://github.com/jegor377/godot-gdgifexporter.git
 [submodule "distro"]
 	path = distro
 	url = https://github.com/bram-dingelstad/godot-gifmaker


### PR DESCRIPTION
Changed submodule path to clone with https:// instead of ssh (which requires ssh key when cloning with `git clone --recursive`)